### PR TITLE
add support for REQL fetch/changes expressions

### DIFF
--- a/client/src/execute.js
+++ b/client/src/execute.js
@@ -1,0 +1,22 @@
+class ExecuteTerm {
+  constructor(sendRequest, reql) {
+    if (reql.build && typeof reql.build === 'function') {
+      this._query = { reql: reql.build() }
+    } else if (Array.isArray(reql)) {
+      this._query = { reql }
+    } else {
+      throw new Error('Not a supported REQL type.')
+    }
+    this._sendRequest = sendRequest
+  }
+
+  watch() {
+    return this._sendRequest('subscribe', this._query)
+  }
+
+  fetch() {
+    return this._sendRequest('query', this._query)
+  }
+}
+
+export default (sendRequest, reql) => new ExecuteTerm(sendRequest, reql)

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -9,6 +9,7 @@ import { Collection, UserDataTerm } from './ast'
 import { HorizonSocket } from './socket'
 import { authEndpoint, TokenStorage, clearAuthTokens } from './auth'
 import { aggregate, model } from './model'
+import execute from './execute'
 
 const defaultHost = typeof window !== 'undefined' && window.location &&
         `${window.location.host}` || 'localhost:8181'
@@ -111,6 +112,7 @@ function Horizon({
   horizon.hasAuthToken = tokenStorage.hasAuthToken.bind(tokenStorage)
   horizon.aggregate = aggregate
   horizon.model = model
+  horizon.execute = reql => execute(sendRequest, reql)
 
   return horizon
 

--- a/server/src/endpoint/blacklist.js
+++ b/server/src/endpoint/blacklist.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const OpCode = require('rethinkdb/proto-def').Term.TermType;
+
+module.exports = [
+  OpCode.DB,
+  OpCode.INSERT_AT,
+  OpCode.DELETE_AT,
+  OpCode.CHANGE_AT,
+  OpCode.SPLICE_AT,
+  OpCode.UPDATE,
+  OpCode.DELETE,
+  OpCode.REPLACE,
+  OpCode.INSERT,
+  OpCode.DB_CREATE,
+  OpCode.DB_DROP,
+  OpCode.DB_LIST,
+  OpCode.TABLE_CREATE,
+  OpCode.TABLE_DROP,
+  OpCode.TABLE_LIST,
+  OpCode.CONFIG,
+  OpCode.STATUS,
+  OpCode.RECONFIGURE,
+  OpCode.REBALANCE,
+  OpCode.SYNC,
+  OpCode.GRANT,
+  OpCode.INDEX_CREATE,
+  OpCode.INDEX_DROP,
+  OpCode.INDEX_LIST,
+  OpCode.INDEX_STATUS,
+  OpCode.INDEX_WAIT,
+  OpCode.INDEX_RENAME,
+];
+

--- a/server/src/endpoint/query.js
+++ b/server/src/endpoint/query.js
@@ -3,6 +3,8 @@
 const query = require('../schema/horizon_protocol').query;
 const check = require('../error.js').check;
 const reql_options = require('./common').reql_options;
+const rereql = require('./rereql');
+const blacklist = require('./blacklist');
 
 const Joi = require('joi');
 const r = require('rethinkdb');
@@ -21,7 +23,10 @@ const object_to_fields = (obj) =>
 const make_reql = (raw_request, metadata) => {
   const parsed = Joi.validate(raw_request.options, query);
   if (parsed.error !== null) { throw new Error(parsed.error.details[0].message); }
+
   const options = parsed.value;
+
+  if (options.reql) { return rereql(options.reql, blacklist); }
 
   const collection = metadata.collection(parsed.value.collection);
   let reql = collection.table;

--- a/server/src/endpoint/rereql.js
+++ b/server/src/endpoint/rereql.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const r = require('rethinkdb');
+
+function visit(reql, fn) {
+  const queue = [ reql ];
+  while (queue.length > 0) {
+    const [ op, args ] = queue.pop();
+    if (fn(op, args) === false) { return false; }
+    args.forEach((term) => Array.isArray(term) && queue.push(term));
+  }
+  return true;
+}
+
+const RDBVal = Object.getPrototypeOf(r.expr(1));
+module.exports = function rereql(reql, blacklist) {
+  const safe = visit(reql, (term) => blacklist.indexOf(term) === -1);
+  if (!safe) {
+    throw new Error('REQL expression contains restricted terms');
+  }
+
+  return Object.create(RDBVal, {
+    build: {
+      value: function() { return reql; },
+      writable: false,
+    },
+    compose: {
+      value: function() { return 'reql(' + JSON.stringify(reql) + ')'; },
+      writable: false,
+    },
+  });
+};

--- a/server/src/schema/horizon_protocol.js
+++ b/server/src/schema/horizon_protocol.js
@@ -36,6 +36,9 @@ const read = Joi.alternatives().try(
       .when('find_all', { is: Joi.array().min(2).required(), then: Joi.forbidden() }),
 
     find_all: Joi.array().items(Joi.object().min(1).label('item').unknown(true)).min(1).optional(),
+  }).unknown(false),
+  Joi.object().keys({
+    reql: Joi.array().required(),
   }).unknown(false)
 );
 


### PR DESCRIPTION
Perhaps needs some more explicit documentation of how to use, but quick summary

```js
import r from '@nio/reconsiderdb-ast'; // when this is published somewhere
import Horizon from '@nio/hz-client'; // if this is where this ends up

const hz = Horizon();
hz.connect();

const reql =r.table('jobs')
  .filter(j => (
    j('submitted_as_whatever').lt(0)
      .or(j('updated_date').gt(r.now()))
  ))
  .without('line_items');
hz.execute(reql).watch().subscribe(console.log);
```

`execute()` support chaining to both `fetch()` and `watch()`. The server-side will block most _non-query_ terms, and return an exception. This includes terms like creating/dropping databases, creating/dropping tables, update/insert/insert/replace, index stuff, and grants. See `client/endpoints/blacklist.js` for the full list.

